### PR TITLE
Fix(closing behaviour): leave editor group empty after closing Yazi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3602,7 +3602,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3619,7 +3618,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3631,13 +3629,11 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3654,7 +3650,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3669,7 +3664,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3681,13 +3675,11 @@
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3703,7 +3695,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "8.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3752,7 +3743,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "9.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3771,7 +3761,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3783,7 +3772,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "6.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3803,7 +3791,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3819,7 +3806,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "4.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3834,7 +3820,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "8.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3850,7 +3835,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
       "version": "20.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3881,7 +3865,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -3890,7 +3873,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -3899,7 +3881,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "6.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3917,7 +3898,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "8.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3929,7 +3909,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3941,7 +3920,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/redact": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -3950,7 +3928,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "9.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3967,7 +3944,6 @@
     },
     "node_modules/npm/node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3976,7 +3952,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.3.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3985,7 +3960,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3998,7 +3972,6 @@
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4007,7 +3980,6 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4016,7 +3988,6 @@
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "7.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4028,7 +3999,6 @@
     },
     "node_modules/npm/node_modules/aggregate-error": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4041,7 +4011,6 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4050,7 +4019,6 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4062,25 +4030,21 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "5.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4096,7 +4060,6 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "2.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4108,7 +4071,6 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4117,7 +4079,6 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "19.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4140,7 +4101,6 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/chownr": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4149,7 +4109,6 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/minizlib": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4162,7 +4121,6 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -4177,7 +4135,6 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/p-map": {
       "version": "7.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4189,7 +4146,6 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/tar": {
       "version": "7.4.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4206,7 +4162,6 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/yallist": {
       "version": "5.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4215,7 +4170,6 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "5.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4227,7 +4181,6 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4236,7 +4189,6 @@
     },
     "node_modules/npm/node_modules/ci-info": {
       "version": "4.1.0",
-      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -4251,7 +4203,6 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "4.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -4263,7 +4214,6 @@
     },
     "node_modules/npm/node_modules/clean-stack": {
       "version": "2.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4272,7 +4222,6 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4285,7 +4234,6 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "7.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4294,7 +4242,6 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4306,19 +4253,16 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/cross-spawn": {
       "version": "7.0.6",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4332,7 +4276,6 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4347,7 +4290,6 @@
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -4359,7 +4301,6 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.3.7",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4376,7 +4317,6 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "5.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4385,19 +4325,16 @@
     },
     "node_modules/npm/node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4406,7 +4343,6 @@
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4415,19 +4351,16 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4436,7 +4369,6 @@
     },
     "node_modules/npm/node_modules/foreground-child": {
       "version": "3.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4452,7 +4384,6 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "3.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4464,7 +4395,6 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "10.4.5",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4484,13 +4414,11 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "8.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4502,13 +4430,11 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4521,7 +4447,6 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "7.0.5",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4534,7 +4459,6 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4546,7 +4470,6 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "7.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4558,7 +4481,6 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4567,7 +4489,6 @@
     },
     "node_modules/npm/node_modules/indent-string": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4576,7 +4497,6 @@
     },
     "node_modules/npm/node_modules/ini": {
       "version": "5.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4585,7 +4505,6 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "7.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4603,7 +4522,6 @@
     },
     "node_modules/npm/node_modules/ip-address": {
       "version": "9.0.5",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4616,7 +4534,6 @@
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "5.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4628,7 +4545,6 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "5.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -4640,7 +4556,6 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4649,13 +4564,11 @@
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jackspeak": {
       "version": "3.4.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -4670,13 +4583,11 @@
     },
     "node_modules/npm/node_modules/jsbn": {
       "version": "1.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4685,7 +4596,6 @@
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -4697,25 +4607,21 @@
       "engines": [
         "node >= 0.2.0"
       ],
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "9.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4728,7 +4634,6 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "7.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4747,7 +4652,6 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "9.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4768,7 +4672,6 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "6.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4780,7 +4683,6 @@
     },
     "node_modules/npm/node_modules/libnpmhook": {
       "version": "11.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4793,7 +4695,6 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "7.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4806,7 +4707,6 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "8.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4821,7 +4721,6 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "10.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4840,7 +4739,6 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "8.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4852,7 +4750,6 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "7.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4865,7 +4762,6 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "7.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4881,13 +4777,11 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "10.4.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "14.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4909,7 +4803,6 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen/node_modules/negotiator": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4918,7 +4811,6 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "9.0.5",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4933,7 +4825,6 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "7.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4942,7 +4833,6 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4954,7 +4844,6 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4971,7 +4860,6 @@
     },
     "node_modules/npm/node_modules/minipass-fetch/node_modules/minizlib": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4984,7 +4872,6 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4996,7 +4883,6 @@
     },
     "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5008,7 +4894,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5020,7 +4905,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5032,7 +4916,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5044,7 +4927,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
       "version": "3.3.6",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5056,7 +4938,6 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "2.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5069,7 +4950,6 @@
     },
     "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5081,7 +4961,6 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -5093,13 +4972,11 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5108,7 +4985,6 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "11.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5132,7 +5008,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5141,7 +5016,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/minizlib": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5154,7 +5028,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/mkdirp": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -5169,7 +5042,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/tar": {
       "version": "7.4.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5186,7 +5058,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
       "version": "5.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5195,7 +5066,6 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "8.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5210,7 +5080,6 @@
     },
     "node_modules/npm/node_modules/nopt/node_modules/abbrev": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5219,7 +5088,6 @@
     },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "7.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5233,7 +5101,6 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "6.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5242,7 +5109,6 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5254,7 +5120,6 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "7.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5266,7 +5131,6 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5275,7 +5139,6 @@
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "12.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5290,7 +5153,6 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "9.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5302,7 +5164,6 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "10.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5317,7 +5178,6 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "11.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5330,7 +5190,6 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "18.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5349,7 +5208,6 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch/node_modules/minizlib": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5362,7 +5220,6 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -5371,7 +5228,6 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5386,13 +5242,11 @@
     },
     "node_modules/npm/node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "19.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5423,7 +5277,6 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5437,7 +5290,6 @@
     },
     "node_modules/npm/node_modules/path-key": {
       "version": "3.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5446,7 +5298,6 @@
     },
     "node_modules/npm/node_modules/path-scurry": {
       "version": "1.11.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5462,7 +5313,6 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "6.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5475,7 +5325,6 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "5.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5484,7 +5333,6 @@
     },
     "node_modules/npm/node_modules/proggy": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5493,7 +5341,6 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -5502,7 +5349,6 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "3.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -5511,13 +5357,11 @@
     },
     "node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5530,7 +5374,6 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5542,7 +5385,6 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "extraneous": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -5550,7 +5392,6 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5562,7 +5403,6 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "5.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5571,7 +5411,6 @@
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5584,7 +5423,6 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5593,7 +5431,6 @@
     },
     "node_modules/npm/node_modules/rimraf": {
       "version": "5.0.10",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5608,13 +5445,11 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.6.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -5626,7 +5461,6 @@
     },
     "node_modules/npm/node_modules/shebang-command": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5638,7 +5472,6 @@
     },
     "node_modules/npm/node_modules/shebang-regex": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5647,7 +5480,6 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "4.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5659,7 +5491,6 @@
     },
     "node_modules/npm/node_modules/sigstore": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5676,7 +5507,6 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/bundle": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5688,7 +5518,6 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/core": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5697,7 +5526,6 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/sign": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5714,7 +5542,6 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/verify": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5728,7 +5555,6 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5738,7 +5564,6 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.8.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5752,7 +5577,6 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "8.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5766,7 +5590,6 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5776,7 +5599,6 @@
     },
     "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5786,13 +5608,11 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.5.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5802,19 +5622,16 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.20",
-      "extraneous": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/sprintf-js": {
       "version": "1.1.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "12.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5826,7 +5643,6 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "4.2.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5841,7 +5657,6 @@
     "node_modules/npm/node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5855,7 +5670,6 @@
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5868,7 +5682,6 @@
     "node_modules/npm/node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5880,7 +5693,6 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "9.4.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5892,7 +5704,6 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.2.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5909,7 +5720,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5921,7 +5731,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5933,7 +5742,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5942,19 +5750,16 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5963,7 +5768,6 @@
     },
     "node_modules/npm/node_modules/tuf-js": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5977,7 +5781,6 @@
     },
     "node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5990,7 +5793,6 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6002,7 +5804,6 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "5.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6014,13 +5815,11 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6030,7 +5829,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6040,7 +5838,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "6.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6049,13 +5846,11 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/which": {
       "version": "5.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6070,7 +5865,6 @@
     },
     "node_modules/npm/node_modules/which/node_modules/isexe": {
       "version": "3.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6079,7 +5873,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6097,7 +5890,6 @@
     "node_modules/npm/node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6114,7 +5906,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6129,7 +5920,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6141,13 +5931,11 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6164,7 +5952,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6179,7 +5966,6 @@
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "6.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6192,7 +5978,6 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },


### PR DESCRIPTION
### Description
This PR changes the behavior when closing Yazi to better handle empty editor groups. Previously, quitting Yazi would always restore the previously active file, even if the user had intentionally closed all files in the editor group before opening Yazi.
Fix https://github.com/dautroc/yazi-vscode/issues/4

### Problem
Two main issues were identified:
- When closing Yazi with 'q' in an empty editor group, it would reopen previously closed files instead of keeping the group empty
- The toggle command wasn't properly closing Yazi when other tabs existed in the same group

### Solution
The changes implement a new behavior where:
- If the current editor group is empty when Yazi closes, it stays empty
- In multi-group scenarios, focus shifts to the first non-empty group (left to right)
- The toggle command now correctly counts tabs only in the current group and always closes Yazi

### Changes Made
1. Added empty group detection:
- New function isCurrentEditorGroupEmpty() that checks if the active group has no non-terminal tabs
- Filters out terminal tabs since they're removed when the terminal closes
2. Added smart group focusing:
- New function focusFirstNonEmptyGroup() that finds and focuses the first non-empty editor group
- Maintains empty group if no other non-empty groups exist
3. Fixed state management:
- Clear previousActiveFile when no active editor exists (prevents holding references to closed files)
- Modified terminal close handler to check group state before restoring files
4. Fixed toggle behavior:
- closeYaziTerminal() now checks tabs only in the current group, not across all groups
- Always disposes Yazi terminal after switching to previous tab

### Breaking Changes
None. This changes the default behavior but improves the user experience by respecting the user's intent when working with empty editor groups.
